### PR TITLE
fix(docs): use contributors custom domain

### DIFF
--- a/docs/contributors/zensical.toml
+++ b/docs/contributors/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "AlienCommons Docs"
-site_url = "https://lazyalienserver.github.io/aliencommons/"
+site_url = "https://developers.aliencommons.com/"
 docs_dir = "docs/en"
 site_dir = "site"
 nav = [
@@ -27,6 +27,6 @@ language = "en"
 
 [project.extra]
 alternate = [
-  { name = "English", link = "/aliencommons/", lang = "en" },
-  { name = "中文", link = "/aliencommons/zh/", lang = "zh" },
+  { name = "English", link = "/", lang = "en" },
+  { name = "中文", link = "/zh/", lang = "zh" },
 ]

--- a/docs/contributors/zensical.zh.toml
+++ b/docs/contributors/zensical.zh.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "AlienCommons 文档"
-site_url = "https://lazyalienserver.github.io/aliencommons/zh/"
+site_url = "https://developers.aliencommons.com/zh/"
 docs_dir = "docs/zh"
 site_dir = "site/zh"
 nav = [
@@ -27,6 +27,6 @@ language = "zh"
 
 [project.extra]
 alternate = [
-  { name = "English", link = "/aliencommons/", lang = "en" },
-  { name = "中文", link = "/aliencommons/zh/", lang = "zh" },
+  { name = "English", link = "/", lang = "en" },
+  { name = "中文", link = "/zh/", lang = "zh" },
 ]


### PR DESCRIPTION
Update both Contributors Zensical configurations to use developers.aliencommons.com as the canonical site URL.

The GitHub Pages custom domain serves the site from the root path, so the language selector now links to / for English and /zh/ for Chinese instead of the repository subpath. This prevents the Chinese selector and stylesheet requests from resolving under the nonexistent /aliencommons/ prefix.

Both English and Chinese strict Zensical builds complete with no issues.